### PR TITLE
Fixed bug with unwrapped html elements

### DIFF
--- a/WebAPI/WebComponents/Meeting/src/EditableItem.js
+++ b/WebAPI/WebComponents/Meeting/src/EditableItem.js
@@ -1,15 +1,40 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Editor, EditorState, RichUtils } from 'draft-js';
 import 'draft-js/dist/Draft.css';
 import parse from 'html-react-parser';
 import { stateFromHTML } from 'draft-js-import-html'
 import { stateToHTML } from 'draft-js-export-html'
 import { editorStyle } from './styles'
+import { useTranslation } from 'react-i18next';
 
 export default function EditableItem(props) {
     const { agendaItem, meetingId, language } = props
     const [userInput, setUserInput] = React.useState(false)
-    const [editorState, setEditorState] = useState(EditorState.createWithContent(stateFromHTML(agendaItem.html)));
+    const [editorState, setEditorState] = useState(EditorState.createEmpty());
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        const wrapUnwrapped = () => {
+            console.log(agendaItem.html)
+            var div = document.createElement('div')
+            div.innerHTML = agendaItem.html
+            var nodes = div.childNodes
+            for (var i = 0; i < nodes.length; i++) {
+                if (nodes[i].nodeName == "H4") {
+                    div.removeChild(nodes[i])
+                }
+                if (nodes[i].nodeType == 3) {
+                    var p = document.createElement('p');
+                    p.textContent = nodes[i].textContent;
+                    div.replaceChild(p, nodes[i])
+                }
+            }
+            console.log(nodes)
+
+            setEditorState(EditorState.createWithContent(stateFromHTML(div.innerHTML)))
+        }
+        wrapUnwrapped()
+    }, [])
 
     const onChange = editorState => {
         setEditorState(editorState)
@@ -29,6 +54,8 @@ export default function EditableItem(props) {
 
     const submitChanges = () => {
         const editedHtml = stateToHTML(editorState.getCurrentContent());
+        const wrappedWithHeader = "<html><body><h4>" + t("Decision") + "</h4>" + editedHtml + "</body></html>"
+
         const agendaPoint = agendaItem.agendaPoint
         const request = {
             method: 'POST',
@@ -37,21 +64,18 @@ export default function EditableItem(props) {
                 'Authorization': 'Bearer ' + localStorage.getItem("userToken")
             },
             body: JSON.stringify({
-                html: editedHtml,
+                html: wrappedWithHeader,
                 meetingId,
                 agendaPoint,
                 language
             })
         }
         fetch('#--API_URL--#/editor/edit', request)
-        agendaItem.html = editedHtml
-
         setUserInput(false)
     }
-
-
     return (
         <div>
+            <h4>{t("Decision")}</h4>
             <div tabIndex="0" onFocus={() => setUserInput(true)} >
                 {
                     userInput ?


### PR DESCRIPTION
Bug: in edit mode (logged in): Päätös/Decision header was placed below text content. This was due to stateFromHTML incorrectly handling unwrapped elements such as "<h4>Title</h4> unwrapped text".

Fix: before setting editorstate, check and wrap html string as necessary.
The Decision header is now removed from editorstate and placed again to the html content before POST along with other tags that are stripped in the editing process. Decision header should not be edited by user, as they have no tools for creating a new header in case of accidental delete.