### PR TITLE
Display: vote minimap, new agendaItems

### DIFF
--- a/WebAPI/WebComponents/Meeting/src/AgendaItem.js
+++ b/WebAPI/WebComponents/Meeting/src/AgendaItem.js
@@ -48,6 +48,46 @@ export default function AgendaItem(props) {
         }
     }, [accordionOpen])
 
+    const displayableHtml = (item) => {
+        var div = document.createElement('div')
+        var newDiv = document.createElement('div')
+        div.innerHTML = item
+        var newItem = div.querySelectorAll(".SisaltoSektio")[0]
+        if (newItem) {
+            const nodes = newItem.childNodes
+            for (var i = 0; i < nodes.length; i++) {
+                if (nodes[i].nodeName == 'H1' || nodes[i].nodeName == 'H2' || nodes[i].nodeName == 'H3' || nodes[i].nodeName == 'H4') {
+                    var b = document.createElement('b')
+                    b.textContent = nodes[i].textContent
+                    newDiv.appendChild(b)
+                } else {
+                    newDiv.appendChild(nodes[i])
+                }
+            }
+            return newDiv.innerHTML
+        } else {
+            const nodes = div.childNodes
+            for (var i = 0; i < nodes.length; i++) {
+                if (nodes[i].nodeName == 'H1' || nodes[i].nodeName == 'H2' || nodes[i].nodeName == 'H3' || nodes[i].nodeName == 'H4') {
+                    var b = document.createElement('b')
+                    b.textContent = nodes[i].textContent
+                    var p = document.createElement('p')
+                    p.appendChild(b)
+                    newDiv.appendChild(p)
+                }
+                else if (nodes[i].nodeType == 3) {
+                    var p = document.createElement('p')
+                    p.textContent = nodes[i].textContent
+                    newDiv.appendChild(p)
+                }
+                else {
+                    newDiv.appendChild(nodes[i])
+                }
+            }
+            return newDiv.innerHTML
+        }
+    }
+
     const decisionResolutionText = t('Decision resolution')
     const decisionText = t('Decision')
     const openText = t('Open')
@@ -117,13 +157,17 @@ export default function AgendaItem(props) {
                         })
                         }
                     </div>
-                    {agenda.html && (editable ?
-                        <EditableItem
-                            agendaItem={agenda}
-                            meetingId={meetingId}
-                            language={"#--LANGUAGE--#"} /> 
-                            : 
-                            <div dangerouslySetInnerHTML={{ __html: agenda.html }} />)}
+                    <div style={{ padding: "20px 0px 20px 0px" }}>
+                        {agenda.html && (editable ?
+                            <EditableItem
+                                agendaItem={agenda}
+                                itemHTML={displayableHtml(agenda.html)}
+                                meetingId={meetingId}
+                                language={"#--LANGUAGE--#"} />
+                            :
+                            <div dangerouslySetInnerHTML={{ __html: displayableHtml(agenda.html) }} />
+                        )}
+                    </div>
                     {statements && <Statements statements={statements}></Statements>}
                     <div style={{ padding: "30px 10px 0 0" }}>
                         <button style={agendaButtonStyle} onClick={() => setShowSeatMap(!showSeatMap)}>
@@ -132,7 +176,7 @@ export default function AgendaItem(props) {
                                     ? <FaCaretUp />
                                     : <FaCaretDown />}
                             </div>
-                            <b>{t("Show seat map")}</b>
+                            {t("Show seat map")}
                         </button>
                     </div>
 

--- a/WebAPI/WebComponents/Meeting/src/SeatMap.js
+++ b/WebAPI/WebComponents/Meeting/src/SeatMap.js
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react'
 import SeatRow from './SeatRow'
 
-const champerStyle = {
+const chamberStyle = {
     fontSize: "65%",
     height: "60em",
     pageBreakInside: "avoid",
@@ -49,7 +49,7 @@ export default function SeatMap(props) {
     }, [seats])
 
     return (
-        <div style={champerStyle}>
+        <div style={chamberStyle}>
             <SeatRow seats={seatMap}></SeatRow>
             <SeatRow rowNr={0} seats={seatMap}></SeatRow>
             <SeatRow rowNr={1} seats={seatMap}></SeatRow>

--- a/WebAPI/WebComponents/Meeting/src/SeatRow.js
+++ b/WebAPI/WebComponents/Meeting/src/SeatRow.js
@@ -87,7 +87,7 @@ const blueDeskStyleBW = {
 const guestBoxStyle = {
     border: "1px dotted #444444",
     marginTop: "2%",
-    marginLeft: "50%"
+    marginLeft: "50%",
 }
 
 const guestRowStyle = {
@@ -95,22 +95,21 @@ const guestRowStyle = {
     marginTop: 0,
     marginBotton: "2px",
     marginLeft: "5px",
-    marginRight: "5px"
+    marginRight: "5px",
 }
 
 const guestSeatStyle = {
     ...seatStyle,
     ...aisleLeftStyle,
-    width: "18%"
+    width: "18%",
 }
 
 export default function SeatRow(props) {
 
-    const { seats, rowNr, showColors } = props
+    const { seats, rowNr, showColors, showName } = props
     const isQuest = !!props.isQuest;
 
     const getSeatStyle = (voteType) => {
-
         switch (voteType) {
             case 0: return showColors ? greenDeskStyle : greenDeskStyleBW
             case 1: return showColors ? redDeskStyle : redDeskStyleBW
@@ -122,7 +121,7 @@ export default function SeatRow(props) {
     const createSeat = (seat) => {
         return (
             <div style={ getSeatStyle(seat?.voteType) }>
-                { seat?.name }
+                {showName && seat?.name }
             </div>
         )
     }

--- a/WebAPI/WebComponents/Meeting/src/Statements.js
+++ b/WebAPI/WebComponents/Meeting/src/Statements.js
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { linkStyle } from "./styles";
+import { headingStyle, linkStyle } from "./styles";
 
 const speechesContainerStyle = {
     columnCount: 2,
@@ -28,7 +28,7 @@ export default function  Statements(props) {
 
     return (
         <div>
-            <h4>{t("Speeches")}</h4>
+            <div style={headingStyle}>{t("Speeches")}</div>
             <div style={speechesContainerStyle}>
                 { statements && statements.map(statement => getStatement(statement)) }
             </div>

--- a/WebAPI/WebComponents/Meeting/src/Voting.js
+++ b/WebAPI/WebComponents/Meeting/src/Voting.js
@@ -7,7 +7,7 @@ import html2canvas from "html2canvas" // DO NOT REMOVE THIS
 import { agendaButtonStyle, headingStyle, linkStyle } from './styles';
 import { FaCaretDown, FaCaretUp } from "react-icons/fa";
 
-const champerStyle = {
+const chamberStyle = {
     fontSize: "65%",
     height: "50em",
     pageBreakInside: "avoid",
@@ -22,7 +22,72 @@ const voteListContainerStyle = {
     boxSizing: "border-box",
     fontSize: "90%"
 }
+const miniChamberStyle = {
+    height: "100px",
+    width: "240px",
+    pageBreakInside: "avoid",
+    backgroundColor: "#dedfe1",
+    margin: 0,
+    padding: 0
+}
 
+const votingInfo = {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    width: "90%"
+}
+
+const voteLegend = {
+    fontWeight: '600',
+    width: '2em',
+    padding:' 2px 2px 2px 2px',
+    marginBottom: '4px',
+    textAlign: 'center',
+    boxSizing: 'border-box',
+    backgroundColor: "#eeeeee",
+    boxSizing: "border-box",
+}
+
+const voteCount = {
+    paddingTop: "2px",
+    paddingBottom: "2px",
+    marginBottom: '4px',
+    boxSizing: 'border-box',
+}
+
+const seatColorStyles = {
+    redDeskStyle: {
+        ...voteLegend,
+        backgroundColor: "#e62224",
+        color: "#ffffff"
+    },
+    redDeskStyleBW: {
+        ...voteLegend,
+        backgroundColor: "#aaa",
+        color: "#000"
+    },
+    greenDeskStyle: {
+        ...voteLegend,
+        backgroundColor: "#64bb46",
+        color: "#ffffff"
+    },
+    greenDeskStyleBW: {
+        ...voteLegend,
+        backgroundColor: "#000",
+        color: "#fff"
+    },
+    blueDeskStyle: {
+        ...voteLegend,
+        backgroundColor: "#98d8e1",
+        color: "#ffffff"
+    },
+    blueDeskStyleBW: {
+        ...voteLegend,
+        backgroundColor: "#fff",
+        color: "#000"
+    }
+}
 
 export default function Voting(props) {
     const [seats, setSeats] = useState([]);
@@ -94,12 +159,34 @@ export default function Voting(props) {
     }
 
     return (
-        <div id="print-area">
+        <div id="print-area" style={{ boxSixing: 'inherit' }}>
             <div style={headingStyle}>{t("Voting")}</div>
-            <div>{voting.forTitleFI}: {voting.forCount}</div>
-            <div>{voting.againstTitleFI}: {voting.againstCount}</div>
-            <div>{t("Empty")}: {voting.emptyCount}</div>
-            <div>{t("Absent")}: {voting.absentCount}</div>
+            <div style={votingInfo}>
+                <div>
+                    <div style={voteCount}>{voting.forTitleFI}: {voting.forCount}</div>
+                    <div style={voteCount}>{voting.againstTitleFI}: {voting.againstCount}</div>
+                    <div style={voteCount}>{t("Empty")}: {voting.emptyCount}</div>
+                    <div style={voteCount}>{t("Absent")}: {voting.absentCount}</div>
+                </div>
+                <div>
+                    <div style={showColors ? seatColorStyles.greenDeskStyle : seatColorStyles.greenDeskStyleBW}>{voting.forCount}</div>
+                    <div style={showColors ? seatColorStyles.redDeskStyle : seatColorStyles.redDeskStyleBW}>{voting.againstCount}</div>
+                    <div style={showColors ? seatColorStyles.blueDeskStyle : seatColorStyles.blueDeskStyleBW}>{voting.emptyCount}</div>
+                    <div style={voteLegend}>{voting.absentCount}</div>
+                </div>
+                <div style={miniChamberStyle}>
+                    <SeatRow showName={false} showColors={showColors} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={0} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={1} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={2} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={3} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={4} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={5} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={6} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={7} seats={seatMap}></SeatRow>
+                    <SeatRow showName={false} showColors={showColors} rowNr={8} seats={seatMap}></SeatRow>
+                </div>
+            </div>
             <div>
                 <div style={{ padding: "30px 10px 0 0" }}>
                     <button style={agendaButtonStyle} onClick={() => setShowVotes(!showVotes)} data-html2canvas-ignore={"true"}>
@@ -113,17 +200,17 @@ export default function Voting(props) {
                 </div>
                 {showVotes &&
                     <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        <div style={champerStyle}>
-                            <SeatRow showColors={showColors} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={0} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={1} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={2} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={3} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={4} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={5} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={6} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={7} seats={seatMap}></SeatRow>
-                            <SeatRow showColors={showColors} rowNr={8} seats={seatMap}></SeatRow>
+                        <div style={chamberStyle}>
+                            <SeatRow showName={true} showColors={showColors} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={0} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={1} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={2} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={3} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={4} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={5} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={6} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={7} seats={seatMap}></SeatRow>
+                            <SeatRow showName={true} showColors={showColors} rowNr={8} seats={seatMap}></SeatRow>
                         </div>
                         <a href='javascript:void(0)' onClick={toggleColors} data-html2canvas-ignore={"true"} style={linkStyle}>
                             {showColors ? t("Show black and white vote map") : t("Show vote map with colors")}

--- a/WebAPI/WebComponents/Meeting/src/Voting.js
+++ b/WebAPI/WebComponents/Meeting/src/Voting.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react'
 import SeatRow from './SeatRow'
 import { jsPDF } from "jspdf"
-import { agendaButtonStyle, titleStyle, linkStyle } from './styles';
+import { agendaButtonStyle, linkStyle, headingStyle } from './styles';
 import { FaCaretDown, FaCaretUp } from "react-icons/fa";
 
 const champerStyle = {
@@ -94,7 +94,7 @@ export default function Voting(props) {
 
     return (
         <div id="print-area">
-            <h4>{t("Voting")}</h4>
+            <div style={headingStyle}>{t("Voting")}</div>
             <div>{voting.forTitleFI}: {voting.forCount}</div>
             <div>{voting.againstTitleFI}: {voting.againstCount}</div>
             <div>{t("Empty")}: {voting.emptyCount}</div>
@@ -131,34 +131,25 @@ export default function Voting(props) {
                             {t("Download voting map pdf")}
                         </a>
                         <div style={voteListContainerStyle} data-html2canvas-ignore={"true"}>
-                            <p>
-                                <div>{t("FOR")}</div>
-                            </p>
-                            <p>
-                                {voting && seatMap.filter(vote => vote.voteType === 0).map(vote => createVoterElement(vote))}
-                            </p>
-                            <p>
-                                <div>{t("AGAINST")}</div>
-                            </p>
-                            <p>
-                                {voting && seatMap.filter(vote => vote.voteType === 1).map(vote => createVoterElement(vote))}
-                            </p>
-                            <p>
-                                <div>{t("EMPTY")}</div>
-                            </p>
-                            <p>
-                                {voting && seatMap.filter(vote => vote.voteType === 2).map(vote => createVoterElement(vote))}
-                            </p>
-                            <p>
-                                <div>{t("ABSENT")}</div>
-                            </p>
-                            <p>
-                                {voting && seatMap.filter(vote => vote.voteType === 3).map(vote => createVoterElement(vote))}
-                            </p>
+                            <div>{t("FOR")}</div>
+                            <br />
+                            {voting && seatMap.filter(vote => vote.voteType === 0).map(vote => createVoterElement(vote))}
+                            <br />
+                            <div>{t("AGAINST")}</div>
+                            <br />
+                            {voting && seatMap.filter(vote => vote.voteType === 1).map(vote => createVoterElement(vote))}
+                            <br />
+                            <div>{t("EMPTY")}</div>
+                            <br />
+                            {voting && seatMap.filter(vote => vote.voteType === 2).map(vote => createVoterElement(vote))}
+                            <br />
+                            <div>{t("ABSENT")}</div>
+                            <br />
+                            {voting && seatMap.filter(vote => vote.voteType === 3).map(vote => createVoterElement(vote))}
                         </div>
                     </div>
                 }
             </div>
-        </div>
+        </div >
     )
 }

--- a/WebAPI/WebComponents/Meeting/src/styles.js
+++ b/WebAPI/WebComponents/Meeting/src/styles.js
@@ -172,6 +172,11 @@ const linkStyle = {
     ...textStyles,
     color: "#0072c6"
 }
+const headingStyle = {
+    ...textStyles,
+    fontWeight: 'bold',
+    marginBottom: '20px'
+}
 
 export {
     itemStyle,
@@ -185,5 +190,6 @@ export {
     headerStyle,
     editorStyle,
     linkStyle,
-    syncBarStyle
+    syncBarStyle,
+    headingStyle
 }

--- a/WebAPI/WebComponents/Meeting/src/styles.js
+++ b/WebAPI/WebComponents/Meeting/src/styles.js
@@ -172,11 +172,6 @@ const linkStyle = {
     ...textStyles,
     color: "#0072c6"
 }
-const headingStyle = {
-    ...textStyles,
-    fontWeight: 'bold',
-    marginBottom: '20px'
-}
 
 export {
     itemStyle,
@@ -190,6 +185,5 @@ export {
     headerStyle,
     editorStyle,
     linkStyle,
-    syncBarStyle,
-    headingStyle
+    syncBarStyle
 }


### PR DESCRIPTION
**Edit handling new structure of agendaitem**
- For new (non-migrated, never before edited) agendaitems, parse and display only the first part of content (class SisaltoSektio). This should display only Päätösehdotus, and no other subheaders.
- For new agendaitems, preserve original html-structure
- For old type agendaitems, or new items that have been modified before this change, display contents in a simple div
- All Headers are now **bold** regular text: This should display correctly on production, and it is editable for the user by using keybinding ctrl+b when editing. This way users can write their own headers.
- 

**Voting minimap and legend**
- Now displaying a voting legend and voting minimap.
- Voting legend should align with vote count text and display correct colors, also in black and white
- Voting minimap is a sized-down version of full vote map. Note: There may be differences on how map is displayed locally and on test site.