### PR TITLE
Net6 to net10 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
+[Bb]in/
+[Oo]bj/
 .vscode/
 .vs/
-WebAPI/obj/
-WebAPI/bin/
 WebAPI/WebComponents/*/dist/
 WebAPI/WebComponents/*/node_modules/
 WebAPI/ScriptFiles/components/*.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bookworm-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 
 LABEL io.openshift.expose-services="8080:http"
-EXPOSE 8080
-ENV ASPNETCORE_URLS=http://*:8080
+EXPOSE 80
+ENV ASPNETCORE_HTTP_PORTS=80
+ENV ASPNETCORE_URLS=http://*:80
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["./WebAPI/WebAPI.csproj", "./"]
 RUN dotnet restore "WebAPI.csproj"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # datapumppu-webapi
 
-![.NET](https://img.shields.io/badge/.NET-6.0-512BD4)
-![ASP.NET Core](https://img.shields.io/badge/ASP.NET%20Core-6.0-purple)
+![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)
+![ASP.NET Core](https://img.shields.io/badge/ASP.NET%20Core-10.0-purple)
 ![Apache Kafka](https://img.shields.io/badge/Apache%20Kafka-Confluent%202.8.0-231F20)
 ![SignalR](https://img.shields.io/badge/SignalR-Real--time-0078D4)
 
@@ -20,10 +20,6 @@ A public-facing ASP.NET Core Web API microservice in the Datapumppu ecosystem th
   - [Built With](#built-with)
   - [Prerequisites](#prerequisites)
   - [Getting Started](#getting-started)
-    - [Installation](#installation)
-    - [Configuration](#configuration)
-    - [Running Locally](#running-locally)
-    - [Docker Setup](#docker-setup)
   - [API Documentation](#api-documentation)
     - [API Overview](#api-overview)
     - [Key Endpoints](#key-endpoints)
@@ -40,7 +36,7 @@ A public-facing ASP.NET Core Web API microservice in the Datapumppu ecosystem th
 
 ## About
 
-The **datapumppu-webapi** is a .NET 6.0 ASP.NET Core microservice that acts as the public API gateway for the Datapumppu ecosystem. It does not own a database; instead, it proxies all data requests to an external Storage API and caches responses in memory with configurable time-to-live durations.
+The **datapumppu-webapi** is a .NET 10.0 ASP.NET Core microservice that acts as the public API gateway for the Datapumppu ecosystem. It does not own a database; instead, it proxies all data requests to an external Storage API and caches responses in memory with configurable time-to-live durations.
 
 This service handles:
 - **Meeting data retrieval** -- Fetches and caches meeting, voting, statement, seat, and reservation data from the Storage API
@@ -135,110 +131,34 @@ sequenceDiagram
 
 Before you begin, ensure you have the following installed:
 
-- **[.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)** -- Required to build and run the application
+- **[.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)** -- Required to build and run the application locally
 - **[Docker](https://www.docker.com/)** -- Required for containerized builds (includes Node.js 16 for web component compilation)
 - **[Node.js 16](https://nodejs.org/)** -- Only needed if building web components outside Docker
 
 **Recommended IDEs:**
-- Visual Studio 2022
+- Visual Studio 2022 / 2025
 - Visual Studio Code with the C# extension
 
 ## Getting Started
 
-### Installation
+This application is designed to be run locally in Docker using **Docker Compose**, which works completely out-of-the-box without the need for manual configuration changes. It automatically builds the .NET 10 WebAPI backend and compiles/embeds the React frontend components.
 
-1. **Clone the repository:**
+### Running Locally with Docker Compose
+
+1. Make sure you have Docker running on your host machine.
+2. Start the services:
    ```bash
-   git clone <repository-url>
-   cd datapumppu-webapi
+   docker-compose up --build
    ```
+3. The WebAPI backend will compile, start, and begin listening on `http://localhost:8081`.
 
-2. **Restore dependencies:**
-   ```bash
-   dotnet restore WebAPI.sln
-   ```
+### Accessing the Frontend Web Component
 
-### Configuration
+A dedicated local test page is provided to let you test and view the embedded frontend React component connected to your running Dockerized backend:
 
-Configure the application using environment variables or `appsettings.Development.json`:
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `STORAGE_URL` | Base URL of the external Storage API | `http://localhost:5154` |
-| `API_URL` | Public base URL of this WebAPI service | `http://localhost:5212` |
-| `JWT_KEY` | Symmetric key for JWT token signing (HS256) | `<JWT_KEY>` |
-| `JWT_ISSUER` | JWT token issuer claim | `http://localhost:5212/` |
-| `JWT_AUDIENCE` | JWT token audience claim | `http://localhost:5212/` |
-| `ALLOWED_HOSTS` | Comma-separated list of allowed CORS origins | `http://localhost:3000` |
-| `KAFKA_BOOTSTRAP_SERVER` | Kafka broker address | `localhost:9092` |
-| `KAFKA_CONSUMER_TOPIC` | Kafka topic for live meeting events | `webapi-topic` |
-| `KAFKA_USER_USERNAME` | Kafka SASL username (production only) | *(set in secrets)* |
-| `KAFKA_USER_PASSWORD` | Kafka SASL password (production only) | *(set in secrets)* |
-| `SSL_CERT_PEM` | PEM certificate for Kafka SSL (production only) | *(set in secrets)* |
-
-**Example `appsettings.Development.json`:**
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "API_URL": "http://localhost:5212",
-  "STORAGE_URL": "http://localhost:5154",
-  "JWT_KEY": "<JWT_KEY>",
-  "JWT_ISSUER": "http://localhost:5212/",
-  "JWT_AUDIENCE": "http://localhost:5212/",
-  "KAFKA_BOOTSTRAP_SERVER": "localhost:9092",
-  "KAFKA_CONSUMER_TOPIC": "webapi-topic"
-}
-```
-
-### Running Locally
-
-1. **Ensure the Storage API is running** at the URL specified in `STORAGE_URL`.
-
-2. **Build and run the application:**
-   ```bash
-   dotnet build WebAPI.sln
-   dotnet run --project WebAPI
-   ```
-
-The application will start on `http://localhost:8080` by default (configurable via `ASPNETCORE_URLS`).
-
-**Verify the application is running:**
-```bash
-curl http://localhost:8080/healthz
-# Expected: Healthy
-```
-
-> **Note:** The web component (`meeting.js`) is only available when built via Docker or by running `npm install && npm run build` in `WebAPI/WebComponents/Meeting/` and copying the output to `WebAPI/ScriptFiles/components/`.
-
-### Docker Setup
-
-**Build Docker image:**
-```bash
-docker build -t datapumppu-webapi:latest .
-```
-
-**Run container:**
-```bash
-docker run -d \
-  --name datapumppu-webapi \
-  -p 8080:8080 \
-  -e STORAGE_URL="http://host.docker.internal:5154" \
-  -e API_URL="http://localhost:8080" \
-  -e JWT_KEY="your-secret-key" \
-  -e JWT_ISSUER="http://localhost:8080/" \
-  -e JWT_AUDIENCE="http://localhost:8080/" \
-  -e ALLOWED_HOSTS="http://localhost:3000" \
-  -e KAFKA_BOOTSTRAP_SERVER="host.docker.internal:9092" \
-  -e KAFKA_CONSUMER_TOPIC="webapi-topic" \
-  datapumppu-webapi:latest
-```
-
-> **Tip:** Use `host.docker.internal` to access services running on the host machine from within the Docker container.
+1. Locate the test file: `WebAPI/WebComponents/Meeting/test-page/test-page-docker.html`.
+2. Open this HTML file **directly in your browser** as a local file (e.g., by double-clicking it in file explorer).
+3. The page will dynamically request and render the fully compiled, templated React frontend module directly from the Dockerized WebAPI instance running at `http://localhost:8081`.
 
 ## API Documentation
 
@@ -460,11 +380,12 @@ Documentation is automatically generated when building with `<GenerateDocumentat
 
 ### Testing
 
-The project does not currently include a unit test project. To build and verify the solution:
+The project includes a robust xUnit unit test suite (`WebAPITests`) to verify core caching, proxy client, and controller logic (such as `MeetingDataProvider` caching behavior and `WebComponentsController` parameter templating).
+
+To run the unit tests:
 
 ```bash
-# Build the solution
-dotnet build WebAPI.sln
+dotnet test
 ```
 
 ---

--- a/WebAPI.sln
+++ b/WebAPI.sln
@@ -5,16 +5,42 @@ VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebAPI.csproj", "{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPITests", "WebAPITests\WebAPITests.csproj", "{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|x64.Build.0 = Debug|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Debug|x86.Build.0 = Debug|Any CPU
 		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|x64.ActiveCfg = Release|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|x64.Build.0 = Release|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|x86.ActiveCfg = Release|Any CPU
+		{9FCEBD1E-6D9F-4C7D-98CF-C84190CA1701}.Release|x86.Build.0 = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|x64.Build.0 = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Debug|x86.Build.0 = Debug|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|x64.ActiveCfg = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|x64.Build.0 = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|x86.ActiveCfg = Release|Any CPU
+		{97527B6B-ADD5-4E75-B880-1B9EEE32AF95}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebAPI/Controllers/DTOs/UserConstant.cs
+++ b/WebAPI/Controllers/DTOs/UserConstant.cs
@@ -3,9 +3,6 @@ namespace WebAPI.Controllers.DTOs
     // We are not taking data from data base so we get data from constant
     public class UserConstant
     {
-        public static List<UserDTO> Users = new()
-            {
-                    new UserDTO(){ Username="admin",Password="admin1"}
-            };
+        public static List<UserDTO> Users = new();
     }
 }

--- a/WebAPI/Controllers/DTOs/WebApiSeatDTO.cs
+++ b/WebAPI/Controllers/DTOs/WebApiSeatDTO.cs
@@ -1,0 +1,13 @@
+namespace WebAPI.Controllers.DTOs
+{
+    public class WebApiSeatDTO
+    {
+        public string? Person { get; set; }
+
+        public string? AdditionalInfoFI { get; set; }
+
+        public string? AdditionalInfoSV { get; set; }
+
+        public string? SeatId { get; set; }
+    }
+}

--- a/WebAPI/Controllers/DTOs/WebApiSeatsDTO.cs
+++ b/WebAPI/Controllers/DTOs/WebApiSeatsDTO.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers.DTOs
+{
+    public class WebApiSeatsDTO
+    {
+        public int VotingNumber { get; set; }
+
+        public List<WebApiSeatDTO> Seats { get; set; } = new List<WebApiSeatDTO>();
+    }
+}

--- a/WebAPI/Controllers/SeatsController.cs
+++ b/WebAPI/Controllers/SeatsController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using WebAPI.Controllers.DTOs;
 using WebAPI.Controllers.Filters;
 using WebAPI.Data;
@@ -39,7 +39,7 @@ namespace WebAPI.Controllers
         /// </summary>
         /// <param name="meetingId">The meeting identifier.</param>
         /// <param name="caseNumber">The case number within the meeting.</param>
-        /// <returns>The seating arrangement data for the specified case.</returns>
+        /// <returns>The list of seating arrangement layout DTOs for the specified case.</returns>
         [HttpGet]
         [Route("{meetingId}/{caseNumber}")]
         public async Task<IActionResult> GetSeats(string meetingId, string caseNumber)

--- a/WebAPI/Data/SeatsDataProvider.cs
+++ b/WebAPI/Data/SeatsDataProvider.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Azure;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using WebAPI.Controllers.DTOs;
 using WebAPI.StorageClient;
 
@@ -15,8 +19,8 @@ namespace WebAPI.Data
         /// </summary>
         /// <param name="meetingId">The meeting identifier.</param>
         /// <param name="caseNumber">The case number.</param>
-        /// <returns>A list of seat assignments, or null if not found.</returns>
-        Task<List<SeatDTO>?> GetSeats(string meetingId, string caseNumber);
+        /// <returns>A list of seat layout snapshots, or null if not found.</returns>
+        Task<List<WebApiSeatsDTO>?> GetSeats(string meetingId, string caseNumber);
 
         /// <summary>
         /// Clears all cached seating data.
@@ -46,7 +50,7 @@ namespace WebAPI.Data
             _semaphore.Release();
         }
 
-        public async Task<List<SeatDTO>?> GetSeats(string meetingId, string caseNumber)
+        public async Task<List<WebApiSeatsDTO>?> GetSeats(string meetingId, string caseNumber)
         {
             var dataKey = $"{meetingId}-{caseNumber}";
             await _semaphore.WaitAsync();
@@ -87,7 +91,7 @@ namespace WebAPI.Data
         {
             public DateTime Timestamp { get; set; }
 
-            public List<SeatDTO>? Seats { get; set; }
+            public List<WebApiSeatsDTO>? Seats { get; set; }
         }
     }
 }

--- a/WebAPI/LiveMeetings/KafkaLiveMeetingObserver.cs
+++ b/WebAPI/LiveMeetings/KafkaLiveMeetingObserver.cs
@@ -38,10 +38,10 @@ namespace WebAPI.LiveMeetings
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            return Task.Run(() => MessageHandler(stoppingToken), stoppingToken);
+            return MessageHandler(stoppingToken);
         }
 
-        private async void MessageHandler(CancellationToken stoppingToken)
+        private async Task MessageHandler(CancellationToken stoppingToken)
         {
             const int WaitTimeMS = 2000;
             var topic = _configuration["KAFKA_CONSUMER_TOPIC"];

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -46,6 +46,7 @@ namespace WebAPI
 
             builder.Services.AddScoped<IStorageApiClient, StorageApiClient>();
             builder.Services.AddScoped<IStorageConnection, StorageConnection>();
+            builder.Services.AddHttpClient();
 
             builder.Services.AddSignalR(options => options.EnableDetailedErrors = true);
 

--- a/WebAPI/StorageClient/DTOs/StorageVotingDTO.cs
+++ b/WebAPI/StorageClient/DTOs/StorageVotingDTO.cs
@@ -26,6 +26,8 @@
 
         public int AbsentCount { get; set; }
 
+        public int VotingNumber { get; set; }
+
         public StorageVoteDTO[] Votes { get; set; } = new StorageVoteDTO[0];
     }
 }

--- a/WebAPI/StorageClient/StorageApiClient.cs
+++ b/WebAPI/StorageClient/StorageApiClient.cs
@@ -105,7 +105,7 @@ namespace WebAPI.StorageClient
         {
             _logger.LogInformation("Executing CheckLogin()");
             using var connection = _storageConnection.CreateConnection();
-            var response = await connection.GetAsync($"api/auth/validate?username={username}&password={password}");
+            var response = await connection.PostAsJsonAsync("api/auth/validate", new { username, password });
             return response.IsSuccessStatusCode;
         }
 

--- a/WebAPI/StorageClient/StorageApiClient.cs
+++ b/WebAPI/StorageClient/StorageApiClient.cs
@@ -22,7 +22,7 @@ namespace WebAPI.StorageClient
         /// <summary>
         /// Requests seating information from the storage API.
         /// </summary>
-        Task<List<SeatDTO>> RequestSeats(string meetingId, string caseNumber);
+        Task<List<WebApiSeatsDTO>> RequestSeats(string meetingId, string caseNumber);
 
         /// <summary>
         /// Requests voting records from the storage API.
@@ -184,14 +184,14 @@ namespace WebAPI.StorageClient
             return await response.Content.ReadFromJsonAsync<List<StorageAgendaSubItemDTO>>() ?? new List<StorageAgendaSubItemDTO>();
         }
 
-        public async Task<List<SeatDTO>> RequestSeats(string meetingId, string caseNumber)
+        public async Task<List<WebApiSeatsDTO>> RequestSeats(string meetingId, string caseNumber)
         {
-            _logger.LogInformation("Executing RequestSeats()");
+            _logger.LogInformation("Executing RequestSeats() for {0}, {1}", meetingId, caseNumber);
             using var connection = _storageConnection.CreateConnection();
             var response = await connection.GetAsync($"api/seats/{meetingId}/{caseNumber}");
-            var seats = await response.Content.ReadFromJsonAsync<SeatDTO[]>();
+            var seats = await response.Content.ReadFromJsonAsync<WebApiSeatsDTO[]>();
 
-            return seats?.ToList() ?? new List<SeatDTO>();
+            return seats?.ToList() ?? new List<WebApiSeatsDTO>();
         }
 
         public async Task<List<StorageVotingDTO>?> RequestVote(string meetingId, string caseNumber)

--- a/WebAPI/StorageClient/StorageConnection.cs
+++ b/WebAPI/StorageClient/StorageConnection.cs
@@ -17,16 +17,18 @@
     /// </summary>
     public class StorageConnection : IStorageConnection
     {
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly IConfiguration _configuration;
 
-        public StorageConnection(IConfiguration configuration)
+        public StorageConnection(IHttpClientFactory httpClientFactory, IConfiguration configuration)
         {
+            _httpClientFactory = httpClientFactory;
             _configuration = configuration;
         }
 
         public HttpClient CreateConnection()
         {
-            var connection = new HttpClient();
+            var connection = _httpClientFactory.CreateClient();
             connection.BaseAddress = new Uri(_configuration["STORAGE_URL"]);
             return connection;
         }

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -9,13 +9,13 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.1" />
-    <PackageReference Include="Confluent.Kafka" Version="2.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.25.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.14.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Pages\" />

--- a/WebAPI/WebComponents/Meeting/src/AgendaItem.js
+++ b/WebAPI/WebComponents/Meeting/src/AgendaItem.js
@@ -350,7 +350,7 @@ export default function AgendaItem(props) {
                     </div>
 
                     {showSeatMap && <SeatMap
-                        seats={seats}
+                        seats={seats?.find(s => s.votingNumber === 0)?.seats || seats?.[0]?.seats || []}
                         meetingId={meetingId}
                         caseNumber={agenda.agendaPoint}
                         updated={updated}
@@ -363,7 +363,7 @@ export default function AgendaItem(props) {
                         voting.map((vote, index) => (
                             <Voting
                                 key={index}
-                                seats={seats}
+                                seats={seats?.[index]?.seats || seats?.[0]?.seats || []}
                                 voting={vote}
                                 meetingId={meetingId}
                                 caseNumber={agenda.agendaPoint}

--- a/WebAPI/WebComponents/Meeting/src/AgendaItem.js
+++ b/WebAPI/WebComponents/Meeting/src/AgendaItem.js
@@ -245,10 +245,12 @@ export default function AgendaItem(props) {
     const decisionText = t('Decision')
     const openText = t('Open')
 
-    var motionPath = `https://paatokset.hel.fi/#--LANGUAGE--#/asia/${agenda?.caseIDLabel?.replace(" ", "-")}#`
-    var decisionPath = `https://paatokset.hel.fi/#--LANGUAGE--#/asia/${decision?.caseID}?paatos=${decision?.nativeId.replace("/[{}]/g", "")}`
+    const isLocalDev = "#--API_URL--#".includes("localhost") || "#--API_URL--#".includes("127.0.0.1") || "#--API_URL--#".includes("#--API_URL--#");
 
-    if (parseInt("#--MEETING_YEAR--#") < 2018 || (parseInt("#--MEETING_YEAR--#") == 2018 && parseInt("#--MEETING_SEQUENCE_NUM--#") < 4)) {
+    var motionPath = isLocalDev ? "#" : `https://paatokset.hel.fi/#--LANGUAGE--#/asia/${agenda?.caseIDLabel?.replace(" ", "-")}#`
+    var decisionPath = isLocalDev ? "#" : `https://paatokset.hel.fi/#--LANGUAGE--#/asia/${decision?.caseID}?paatos=${decision?.nativeId.replace("/[{}]/g", "")}`
+
+    if (!isLocalDev && (parseInt("#--MEETING_YEAR--#") < 2018 || (parseInt("#--MEETING_YEAR--#") == 2018 && parseInt("#--MEETING_SEQUENCE_NUM--#") < 4))) {
         motionPath = "https://dev.hel.fi/paatokset/asia/" + agenda?.caseIDLabel?.replace(" ", "-").toLowerCase() + "/kvsto-#--MEETING_YEAR--#-#--MEETING_SEQUENCE_NUM--#"
         decisionPath = "https://dev.hel.fi/paatokset/asia/" + decision?.caseID
     }

--- a/WebAPI/WebComponents/Meeting/src/Voting.js
+++ b/WebAPI/WebComponents/Meeting/src/Voting.js
@@ -126,32 +126,34 @@ export default function Voting(props) {
 
     useEffect(() => {
         const tempSeatMap = []
-        seats.forEach(seat => {
-            let seatId = Number(seat.seatId);
-            if (seatId > 100) {
-                return
-            }
-
-            let name = seat.person;
-            if ("fi" === "#--LANGUAGE--#".toLowerCase()) {
-                name += seat.additionalInfoFI?.length > 0 ? ` (${seat.additionalInfoFI})` : ""
-            } else {
-                name += seat.additionalInfoSV?.length > 0 ? ` (${seat.additionalInfoSV})` : ""
-            }
-
-            const vote = voting?.votes?.find(vote => vote.name === seat.person)
-            const voteType = vote ? vote.voteType : 3
-            if (vote !== undefined) {
-                vote.name = name
-            }
-
-            if (!isNaN(seatId)) {
-                tempSeatMap[seatId] = {
-                    name,
-                    voteType,
+        if (seats) {
+            seats.forEach(seat => {
+                let seatId = Number(seat.seatId);
+                if (seatId > 100) {
+                    return
                 }
-            }
-        })
+
+                let name = seat.person;
+                if ("fi" === "#--LANGUAGE--#".toLowerCase()) {
+                    name += seat.additionalInfoFI?.length > 0 ? ` (${seat.additionalInfoFI})` : ""
+                } else {
+                    name += seat.additionalInfoSV?.length > 0 ? ` (${seat.additionalInfoSV})` : ""
+                }
+
+                const vote = voting?.votes?.find(vote => vote.name === seat.person)
+                const voteType = vote ? vote.voteType : 3
+                if (vote !== undefined) {
+                    vote.name = name
+                }
+
+                if (!isNaN(seatId)) {
+                    tempSeatMap[seatId] = {
+                        name,
+                        voteType,
+                    }
+                }
+            })
+        }
         setSeatMap(tempSeatMap)
     }, [seats, voting])
 

--- a/WebAPI/WebComponents/Meeting/test-page/test-page-docker.html
+++ b/WebAPI/WebComponents/Meeting/test-page/test-page-docker.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+      <script
+      src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"
+      crossorigin
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"
+      crossorigin
+    ></script>
+    <script
+      type="module"
+      src="http://localhost:8081/components/meeting.js?year=2023&sequenceNumber=8&lang=fi"
+    ></script>
+    <div id="meeting"></div>
+  </body>
+</html>

--- a/WebAPITests/MeetingDataProviderTests.cs
+++ b/WebAPITests/MeetingDataProviderTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using WebAPI.Data;
+using WebAPI.StorageClient;
+using WebAPI.StorageClient.DTOs;
+using Xunit;
+
+namespace WebAPITests
+{
+    public class MeetingDataProviderTests
+    {
+        [Fact]
+        public async Task GetMeeting_ReturnsMeetingFromApiClient_OnCacheMiss()
+        {
+            // Arrange
+            var year = "2026";
+            var sequenceNumber = "12";
+            var language = "fi";
+            var expectedMeeting = new StorageMeetingDTO { MeetingID = "test-id-123", Name = "Test Meeting" };
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+            var storageApiClientMock = new Mock<IStorageApiClient>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns(storageApiClientMock.Object);
+
+            storageApiClientMock
+                .Setup(x => x.RequestMeeting(year, sequenceNumber, language))
+                .ReturnsAsync(expectedMeeting);
+
+            var provider = new MeetingDataProvider(serviceProviderMock.Object);
+
+            // Act
+            var result = await provider.GetMeeting(year, sequenceNumber, language);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("test-id-123", result.MeetingID);
+            Assert.Equal("Test Meeting", result.Name);
+
+            storageApiClientMock.Verify(x => x.RequestMeeting(year, sequenceNumber, language), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetMeeting_ReturnsCachedMeeting_OnCacheHit()
+        {
+            // Arrange
+            var year = "2026";
+            var sequenceNumber = "12";
+            var language = "fi";
+            var expectedMeeting = new StorageMeetingDTO { MeetingID = "test-id-123", Name = "Test Meeting" };
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+            var storageApiClientMock = new Mock<IStorageApiClient>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns(storageApiClientMock.Object);
+
+            storageApiClientMock
+                .Setup(x => x.RequestMeeting(year, sequenceNumber, language))
+                .ReturnsAsync(expectedMeeting);
+
+            var provider = new MeetingDataProvider(serviceProviderMock.Object);
+
+            // Act - Request first time (Cache Miss)
+            var result1 = await provider.GetMeeting(year, sequenceNumber, language);
+
+            // Act - Request second time (Cache Hit)
+            var result2 = await provider.GetMeeting(year, sequenceNumber, language);
+
+            // Assert
+            Assert.Same(result1, result2);
+            storageApiClientMock.Verify(x => x.RequestMeeting(year, sequenceNumber, language), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetMeeting_FetchesFromApiClient_OnCacheExpiry()
+        {
+            // Arrange
+            var year = "2026";
+            var sequenceNumber = "12";
+            var language = "fi";
+            var expectedMeeting1 = new StorageMeetingDTO { MeetingID = "test-id-1", Name = "Meeting 1" };
+            var expectedMeeting2 = new StorageMeetingDTO { MeetingID = "test-id-2", Name = "Meeting 2" };
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+            var storageApiClientMock = new Mock<IStorageApiClient>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns(storageApiClientMock.Object);
+
+            storageApiClientMock
+                .SetupSequence(x => x.RequestMeeting(year, sequenceNumber, language))
+                .ReturnsAsync(expectedMeeting1)
+                .ReturnsAsync(expectedMeeting2);
+
+            var provider = new MeetingDataProvider(serviceProviderMock.Object);
+
+            // Act - First request (Cache Miss)
+            var result1 = await provider.GetMeeting(year, sequenceNumber, language);
+            Assert.Equal("test-id-1", result1?.MeetingID);
+
+            // Use reflection to modify the cache entry timestamp to trigger expiration
+            var field = typeof(MeetingDataProvider).GetField("_dataCache", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            var dataCache = (ConcurrentDictionary<string, MeetingDataCache>)field.GetValue(provider)!;
+            
+            var cacheKey = $"{year}-{sequenceNumber}-{language}";
+            Assert.True(dataCache.TryGetValue(cacheKey, out var cacheItem));
+            Assert.NotNull(cacheItem);
+            
+            // Set timestamp to 6 minutes ago (cache limit is 5 minutes)
+            cacheItem.Timestamp = DateTime.UtcNow.AddMinutes(-6);
+
+            // Act - Second request (Cache Expired, should call API again)
+            var result2 = await provider.GetMeeting(year, sequenceNumber, language);
+            Assert.Equal("test-id-2", result2?.MeetingID);
+
+            storageApiClientMock.Verify(x => x.RequestMeeting(year, sequenceNumber, language), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetMeeting_ThrowsInvalidOperationException_WhenApiClientResolutionFails()
+        {
+            // Arrange
+            var year = "2026";
+            var sequenceNumber = "12";
+            var language = "fi";
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            // Mock returns null for IStorageApiClient
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns((IStorageApiClient?)null);
+
+            var provider = new MeetingDataProvider(serviceProviderMock.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                provider.GetMeeting(year, sequenceNumber, language)
+            );
+        }
+    }
+}

--- a/WebAPITests/SeatsDataProviderTests.cs
+++ b/WebAPITests/SeatsDataProviderTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using WebAPI.Controllers.DTOs;
+using WebAPI.Data;
+using WebAPI.StorageClient;
+using Xunit;
+
+namespace WebAPITests
+{
+    public class SeatsDataProviderTests
+    {
+        [Fact]
+        public async Task GetSeats_ReturnsSeatsFromApiClient_OnCacheMiss()
+        {
+            // Arrange
+            var meetingId = "meeting-1";
+            var caseNumber = "5";
+            
+            var expectedSeats = new List<WebApiSeatsDTO>
+            {
+                new WebApiSeatsDTO
+                {
+                    VotingNumber = 0,
+                    Seats = new List<WebApiSeatDTO>
+                    {
+                        new WebApiSeatDTO { SeatId = "1", Person = "John Doe" }
+                    }
+                }
+            };
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+            var storageApiClientMock = new Mock<IStorageApiClient>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns(storageApiClientMock.Object);
+
+            storageApiClientMock
+                .Setup(x => x.RequestSeats(meetingId, caseNumber))
+                .ReturnsAsync(expectedSeats);
+
+            var provider = new SeatsDataProvider(serviceProviderMock.Object);
+
+            // Act
+            var result = await provider.GetSeats(meetingId, caseNumber);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(0, result[0].VotingNumber);
+            Assert.Single(result[0].Seats);
+            Assert.Equal("John Doe", result[0].Seats[0].Person);
+
+            storageApiClientMock.Verify(x => x.RequestSeats(meetingId, caseNumber), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetSeats_ReturnsCachedSeats_OnCacheHit()
+        {
+            // Arrange
+            var meetingId = "meeting-1";
+            var caseNumber = "5";
+
+            var expectedSeats = new List<WebApiSeatsDTO>
+            {
+                new WebApiSeatsDTO
+                {
+                    VotingNumber = 1,
+                    Seats = new List<WebApiSeatDTO>
+                    {
+                        new WebApiSeatDTO { SeatId = "12", Person = "Jane Smith" }
+                    }
+                }
+            };
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceScopeMock = new Mock<IServiceScope>();
+            var scopeServiceProviderMock = new Mock<IServiceProvider>();
+            var storageApiClientMock = new Mock<IStorageApiClient>();
+
+            serviceProviderMock
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactoryMock.Object);
+
+            serviceScopeFactoryMock
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScopeMock.Object);
+
+            serviceScopeMock
+                .Setup(x => x.ServiceProvider)
+                .Returns(scopeServiceProviderMock.Object);
+
+            scopeServiceProviderMock
+                .Setup(x => x.GetService(typeof(IStorageApiClient)))
+                .Returns(storageApiClientMock.Object);
+
+            storageApiClientMock
+                .Setup(x => x.RequestSeats(meetingId, caseNumber))
+                .ReturnsAsync(expectedSeats);
+
+            var provider = new SeatsDataProvider(serviceProviderMock.Object);
+
+            // Act - Request first time (Cache Miss)
+            var result1 = await provider.GetSeats(meetingId, caseNumber);
+
+            // Act - Request second time (Cache Hit)
+            var result2 = await provider.GetSeats(meetingId, caseNumber);
+
+            // Assert
+            Assert.Same(result1, result2);
+            storageApiClientMock.Verify(x => x.RequestSeats(meetingId, caseNumber), Times.Once);
+        }
+    }
+}

--- a/WebAPITests/StorageApiClientTests.cs
+++ b/WebAPITests/StorageApiClientTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using WebAPI.StorageClient;
+using Xunit;
+
+namespace WebAPITests
+{
+    public class StorageApiClientTests
+    {
+        [Fact]
+        public async Task CheckLogin_ReturnsTrue_WhenResponseIsSuccess()
+        {
+            // Arrange
+            var loggerMock = new Mock<ILogger<StorageApiClient>>();
+            var storageConnectionMock = new Mock<IStorageConnection>();
+
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock
+               .Protected()
+               // Setup the PROTECTED method to mock
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               // prepare the expected response of the mocked http call
+               .ReturnsAsync(new HttpResponseMessage()
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent("[{'id':1,'value':'1'}]"),
+               })
+               .Verifiable();
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new System.Uri("http://test.com/")
+            };
+
+            storageConnectionMock.Setup(x => x.CreateConnection()).Returns(httpClient);
+
+            var apiClient = new StorageApiClient(loggerMock.Object, storageConnectionMock.Object);
+
+            // Act
+            var result = await apiClient.CheckLogin("testuser", "testpass");
+
+            // Assert
+            Assert.True(result);
+            
+            // Verify that it sent a POST request
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Post && req.RequestUri.ToString() == "http://test.com/api/auth/validate"
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+    }
+}

--- a/WebAPITests/WebAPITests.csproj
+++ b/WebAPITests/WebAPITests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebAPI\WebAPI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WebAPITests/WebComponentsControllerTests.cs
+++ b/WebAPITests/WebComponentsControllerTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using WebAPI.Controllers;
+using Xunit;
+
+namespace WebAPITests
+{
+    public class WebComponentsControllerTests : IDisposable
+    {
+        private const string DummyFileDirectory = "./ScriptFiles/components";
+        private const string DummyFilePath = "./ScriptFiles/components/meeting.js";
+        private readonly string _originalFileContent = "API: #--API_URL--#, YEAR: #--MEETING_YEAR--#, SEQ: #--MEETING_SEQUENCE_NUM--#, LANG: #--LANGUAGE--#";
+
+        public WebComponentsControllerTests()
+        {
+            // Ensure the directory and dummy file exist for tests
+            Directory.CreateDirectory(DummyFileDirectory);
+            File.WriteAllText(DummyFilePath, _originalFileContent);
+        }
+
+        public void Dispose()
+        {
+            // Clean up the dummy file and directory after tests
+            if (File.Exists(DummyFilePath))
+            {
+                File.Delete(DummyFilePath);
+            }
+            if (Directory.Exists(DummyFileDirectory) && Directory.GetFiles(DummyFileDirectory).Length == 0)
+            {
+                Directory.Delete(DummyFileDirectory);
+            }
+        }
+
+        [Fact]
+        public async Task GetMeeting_ReturnsFileResultWithReplacedPlaceholders_OnValidInput()
+        {
+            // Arrange
+            var configMock = new Mock<IConfiguration>();
+            configMock.Setup(c => c["API_URL"]).Returns("http://localhost:8081");
+
+            var loggerMock = new Mock<ILogger<WebComponentsController>>();
+
+            var controller = new WebComponentsController(configMock.Object, loggerMock.Object);
+
+            // Act
+            var result = await controller.GetMeeting("2026", "42", "fi");
+
+            // Assert
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("application/javascript", fileResult.ContentType);
+
+            var fileContent = Encoding.UTF8.GetString(fileResult.FileContents);
+            Assert.Equal("API: http://localhost:8081, YEAR: 2026, SEQ: 42, LANG: fi", fileContent);
+        }
+
+        [Fact]
+        public async Task GetMeeting_Returns500_WhenApiUrlConfigIsMissing()
+        {
+            // Arrange
+            var configMock = new Mock<IConfiguration>();
+            configMock.Setup(c => c["API_URL"]).Returns((string?)null); // Missing API_URL
+
+            var loggerMock = new Mock<ILogger<WebComponentsController>>();
+
+            var controller = new WebComponentsController(configMock.Object, loggerMock.Object);
+
+            // Act
+            var result = await controller.GetMeeting("2026", "42", "fi");
+
+            // Assert
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status500InternalServerError, statusCodeResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetMeeting_Returns500_WhenYearIsInvalid()
+        {
+            // Arrange
+            var configMock = new Mock<IConfiguration>();
+            configMock.Setup(c => c["API_URL"]).Returns("http://localhost:8081");
+
+            var loggerMock = new Mock<ILogger<WebComponentsController>>();
+
+            var controller = new WebComponentsController(configMock.Object, loggerMock.Object);
+
+            // Act - Year is not a valid integer
+            var result = await controller.GetMeeting("invalid-year", "42", "fi");
+
+            // Assert
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status500InternalServerError, statusCodeResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetMeeting_Returns500_WhenSequenceNumberIsInvalid()
+        {
+            // Arrange
+            var configMock = new Mock<IConfiguration>();
+            configMock.Setup(c => c["API_URL"]).Returns("http://localhost:8081");
+
+            var loggerMock = new Mock<ILogger<WebComponentsController>>();
+
+            var controller = new WebComponentsController(configMock.Object, loggerMock.Object);
+
+            // Act - Sequence number is not a valid integer
+            var result = await controller.GetMeeting("2026", "invalid-seq", "fi");
+
+            // Assert
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status500InternalServerError, statusCodeResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetMeeting_Returns500_WhenLanguageIsInvalid()
+        {
+            // Arrange
+            var configMock = new Mock<IConfiguration>();
+            configMock.Setup(c => c["API_URL"]).Returns("http://localhost:8081");
+
+            var loggerMock = new Mock<ILogger<WebComponentsController>>();
+
+            var controller = new WebComponentsController(configMock.Object, loggerMock.Object);
+
+            // Act - Language is not supported (e.g., French "fr" or Spanish "es")
+            var result = await controller.GetMeeting("2026", "42", "fr");
+
+            // Assert
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status500InternalServerError, statusCodeResult.StatusCode);
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+name: datapumppu
+
+services:
+  webapi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: webapi
+    ports:
+      - "8081:80"
+    environment:
+      - KAFKA_BOOTSTRAP_SERVER=shared-kafka:9092 # Kafka docker compose in datapumppu-storage repository
+      - ASPNETCORE_ENVIRONMENT=Development
+      - API_URL=http://localhost:8081
+      - ALLOWED_HOSTS=http://localhost:8081,null,http://localhost:3000,http://127.0.0.1:5500
+      - STORAGE_URL=http://storage-service
+
+    networks:
+      - datapumppu-network
+
+networks:
+  datapumppu-network:
+    external: true


### PR DESCRIPTION
**Backend**

- Updated .NET6 to .NET10
- Seats for different agendas are now also separated by votings. If people move between seats between votings, the frontend is able to display this correctly.
- Changed login endpoint between Webapi and Storage from GET to POST request to better reflect the login intent and avoid sending credentials in request URL.
- Reworked HttpClient usage so that new client instance is not generated per request but are reused from centralized pool of clients.
- async void replaced with async task in some cases (safer in case of errors)
- Several new tests related to the changes
- Simple Docker setup for local development and testing

**Frontend**

- Updated React and React Dom from 18.2.0 to 19.2.7
- Removed html-react-parser (not supported in React19)
- Removed draft-js and related libraries (not supported in React19)
	-There libraries were replaced by dependency free implementation as the rich text editor features were not actually used
- Added DOMPurify to HTML sanitize all instances where dangerouslySetInnerHTML was used (defends against XSS)
- appsettings.development.json JWT KEY fixed to have long enough lenght (at least 256bits)
- updated node-builder 16 to version 22 in dockerfile
- Improved displaying of voting maps on small devices